### PR TITLE
Allow requiring this gem correctly

### DIFF
--- a/lib/normalizr.rb
+++ b/lib/normalizr.rb
@@ -1,0 +1,4 @@
+require 'normalizr/array_of'
+require 'normalizr/bag'
+require 'normalizr/normalizr'
+require 'normalizr/schema'

--- a/normalizr.rb.gemspec
+++ b/normalizr.rb.gemspec
@@ -12,4 +12,6 @@ Gem::Specification.new do |s|
   ]
   s.homepage    = 'https://github.com/chrokh/normalizr'
   s.license     = 'MIT'
+
+  s.add_development_dependency 'rspec', '~> 3.0'
 end

--- a/spec/integration/normalizer_spec.rb
+++ b/spec/integration/normalizer_spec.rb
@@ -1,6 +1,4 @@
-require 'normalizr/normalizr'
-require 'normalizr/schema'
-require 'normalizr/array_of'
+require 'normalizr'
 
 describe Normalizr do
 


### PR DESCRIPTION
When this gem is added to a project, you cannot just require 'normalizr'
Instead you must require each file in lib/normalizr separately. This
adds a new file lib/normalizr.rb that requires all those files. This
allows you to require 'normalizr' just fine.